### PR TITLE
Update dependencies and imports to work with most current version of base and GHC 8.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+
+dist/
+
+# Ignore cabal sandboxes
+.cabal-sandbox
+cabal.sandbox.config

--- a/effect-monad.cabal
+++ b/effect-monad.cabal
@@ -47,5 +47,4 @@ library
                         Control.Effect.Helpers.List
                         
   build-depends:        base < 5,
-                        type-level-sets >= 0.6 && < 0.7
-
+                        type-level-sets == 0.5

--- a/effect-monad.cabal
+++ b/effect-monad.cabal
@@ -15,7 +15,7 @@ maintainer:             Dominic Orchard
 stability:              experimental
 build-type:             Simple
 cabal-version:          >= 1.6
-tested-with:            GHC == 7.8.2
+tested-with:            GHC == 7.10.3 && GHC == 8.0.1
 
 extra-source-files:     examples/*.hs
 

--- a/effect-monad.cabal
+++ b/effect-monad.cabal
@@ -47,6 +47,5 @@ library
                         Control.Effect.Helpers.List
                         
   build-depends:        base < 5,
-                        ghc-prim,
-                        type-level-sets >= 0.5
+                        type-level-sets >= 0.6 && < 0.7
 

--- a/src/Control/Coeffect.hs
+++ b/src/Control/Coeffect.hs
@@ -3,7 +3,7 @@
 
 module Control.Coeffect where 
 
-import GHC.Prim
+import GHC.Exts ( Constraint )
 
 {- Coeffect parameterised comonad
 

--- a/src/Control/Effect.hs
+++ b/src/Control/Effect.hs
@@ -3,7 +3,7 @@
 module Control.Effect where 
 
 import Prelude hiding (Monad(..))
-import GHC.Prim    
+import GHC.Exts ( Constraint )    
 
 {-| Specifies "parametric effect monads" which are essentially monads but
      annotated by a type-level monoid formed by 'Plus' and 'Unit' -}

--- a/src/Control/Effect/Cond.hs
+++ b/src/Control/Effect/Cond.hs
@@ -2,7 +2,7 @@
 
 module Control.Effect.Cond where
 
-import GHC.Prim
+import GHC.Exts ( Constraint )
 
 {-| Provides a conditional using an 'alternation' operation, as opposed to using
    'Subeffect' -}

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -8,7 +8,7 @@ import Control.Effect
 import Data.Type.Set
 import Prelude hiding (Monad(..))
 import GHC.TypeLits
-import GHC.Prim
+import GHC.Exts ( Constraint )
 
 {-| Provides a effect-parameterised version of the class reader monad. Effects
    are sets of variable-type pairs, providing an effect system for reader effects. -}


### PR DESCRIPTION
I have updated the packages dependencies to work with the most current version of GHC and base.

Would be happy to see a new version of this package rollout to Hackage soon.

This should solve issue #7.