### PR TITLE
fix: hide prelude fail function to avoid ambiguous ocurrence

### DIFF
--- a/src/Control/Effect/Parameterised.hs
+++ b/src/Control/Effect/Parameterised.hs
@@ -1,6 +1,7 @@
 -- Used to make the types extra clear
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
 -- This module implement parameterised monads due to Bob Atkey
 -- (see 'Parameterised Notions of Computing' JFP 2009)
@@ -9,7 +10,7 @@
 module Control.Effect.Parameterised ((>>), PMonad(..), fail, ifThenElse) where
 
 -- Bye Monads... as we know them
-import Prelude hiding (Monad(..))
+import Prelude hiding (Monad(..), fail)
 
 -- Hello Parameterised Monads
 class PMonad (pm :: k -> k -> * -> *) where

--- a/src/Control/Effect/Parameterised/ExtensibleState.hs
+++ b/src/Control/Effect/Parameterised/ExtensibleState.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RebindableSyntax #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
 module Control.Effect.Parameterised.ExtensibleState
           (State(..), Get, Put, Update, get, put, modify
           , PMonad(..), (>>), ifThenElse, fail) where
 
-import Prelude hiding (Monad(..))
+import Prelude hiding (Monad(..), fail)
 import Control.Effect.Parameterised
 import Control.Effect.Parameterised.State
 import Data.Type.Map

--- a/src/Control/Effect/Parameterised/SafeFiles.hs
+++ b/src/Control/Effect/Parameterised/SafeFiles.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
 module Control.Effect.Parameterised.SafeFiles
          (openFile, hGetChar, hPutChar, hClose, hIsEOF, runSafeFiles
@@ -15,7 +16,7 @@ module Control.Effect.Parameterised.SafeFiles
          , PMonad(..), (>>), ifThenElse, fail) where
 
 -- Bye Monads... as we know them
-import Prelude hiding (Monad(..))
+import Prelude hiding (Monad(..), fail)
 import Control.Effect.Parameterised
 
 -- Import qualified versions of standard code we want to wrap


### PR DESCRIPTION
Fix a compilation error that occurs with modern versions of GHC

```
Building library for effect-monad-0.8.1.0..
[ 1 of 22] Compiling Control.Coeffect ( src/Control/Coeffect.hs, dist/build/Control/Coeffect.o )
[ 2 of 22] Compiling Control.Coeffect.Coreader ( src/Control/Coeffect/Coreader.hs, dist/build/Control/Coeffect/Coreader.o )
[ 3 of 22] Compiling Control.Effect   ( src/Control/Effect.hs, dist/build/Control/Effect.o )
[ 4 of 22] Compiling Control.Effect.Cond ( src/Control/Effect/Cond.hs, dist/build/Control/Effect/Cond.o )
[ 5 of 22] Compiling Control.Effect.Counter ( src/Control/Effect/Counter.hs, dist/build/Control/Effect/Counter.o )
[ 6 of 22] Compiling Control.Effect.CounterNat ( src/Control/Effect/CounterNat.hs, dist/build/Control/Effect/CounterNat.o )
[ 7 of 22] Compiling Control.Effect.Helpers.List ( src/Control/Effect/Helpers/List.hs, dist/build/Control/Effect/Helpers/List.o )
[ 8 of 22] Compiling Control.Effect.Maybe ( src/Control/Effect/Maybe.hs, dist/build/Control/Effect/Maybe.o )
[ 9 of 22] Compiling Control.Effect.Monad ( src/Control/Effect/Monad.hs, dist/build/Control/Effect/Monad.o )
[10 of 22] Compiling Control.Effect.Parameterised ( src/Control/Effect/Parameterised.hs, dist/build/Control/Effect/Parameterised.o )

src/Control/Effect/Parameterised.hs:9:56: error:
    Ambiguous occurrence ‘fail’
    It could refer to
       either ‘Prelude.fail’,
              imported from ‘Prelude’ at src/Control/Effect/Parameterised.hs:12:1-33
              (and originally defined in ‘Control.Monad.Fail’)
           or ‘Control.Effect.Parameterised.fail’,
              defined at src/Control/Effect/Parameterised.hs:27:1
  |
9 | module Control.Effect.Parameterised ((>>), PMonad(..), fail, ifThenElse) where
  |
```