### PR TITLE
Now complies with lts-24.6

### DIFF
--- a/src/Control/Coeffect.hs
+++ b/src/Control/Coeffect.hs
@@ -4,6 +4,7 @@
 module Control.Coeffect where 
 
 import GHC.Exts ( Constraint )
+import Data.Kind (Type)
 
 {- Coeffect parameterised comonad
 
@@ -15,7 +16,7 @@ by Petricek, Orchard, Mycroft: http://www.cl.cam.ac.uk/~dao29/publ/coeffects-ica
 
 {-| Specifies "parametric coeffect comonads" which are essentially comonads but
      annotated by a type-level monoid formed by 'Plus' and 'Unit' -}
-class Coeffect (c :: k -> * -> *) where
+class Coeffect (c :: k -> Type -> Type) where
     type Inv c (s :: k) (t :: k) :: Constraint
     type Inv c s t = ()
 
@@ -32,11 +33,11 @@ class Coeffect (c :: k -> * -> *) where
     extend :: Inv c s t => (c t a -> b) -> c (Plus c s t) a -> c s b
 
 {-| Zips two coeffecting computations together -}
-class CoeffectZip (c :: k -> * -> *) where
+class CoeffectZip (c :: k -> Type -> Type) where
     type Meet c (s :: k) (t :: k) :: k
     type CzipInv c (s :: k) (t :: k) :: Constraint
     czip :: CzipInv c s t => c s a -> c t b -> c (Meet c s t) (a, b)
 
 {-| Specifies sub-coeffecting behaviour -}
-class Subcoeffect (c :: k -> * -> *) s t where
+class Subcoeffect (c :: k -> Type -> Type) s t where
     subco :: c s a -> c t a

--- a/src/Control/Coeffect/Coreader.hs
+++ b/src/Control/Coeffect/Coreader.hs
@@ -6,10 +6,11 @@ module Control.Coeffect.Coreader where
 import Control.Coeffect
 import Data.Type.Map
 import GHC.TypeLits
+import Data.Kind
 
 {-| Provides 'reader monad'-like behaviour but as a comonad, using an indexed
     version of the product comonad -}
-data IxCoreader (s :: [Mapping Symbol *]) a = IxR { runCoreader :: (a, Map s) }
+data IxCoreader (s :: [Mapping Symbol Type]) a = IxR { runCoreader :: (a, Map s) }
 
 instance Coeffect IxCoreader where
     type Inv IxCoreader s t = (Unionable s t, Split s t (Union s t))

--- a/src/Control/Effect.hs
+++ b/src/Control/Effect.hs
@@ -1,13 +1,14 @@
 {-# LANGUAGE KindSignatures, TypeFamilies, ConstraintKinds, PolyKinds, MultiParamTypeClasses #-}
 
-module Control.Effect where 
+module Control.Effect (Effect(..), Subeffect(..)) where 
 
 import Prelude hiding (Monad(..))
 import GHC.Exts ( Constraint )    
+import Data.Kind (Type)
 
 {-| Specifies "parametric effect monads" which are essentially monads but
      annotated by a type-level monoid formed by 'Plus' and 'Unit' -}
-class Effect (m :: k -> * -> *) where
+class Effect (m :: k -> Type -> Type) where
 
    {-| Effect of a trivially effectful computation |-}
    type Unit m :: k
@@ -33,6 +34,6 @@ class Effect (m :: k -> * -> *) where
 fail = undefined
 
 {-| Specifies subeffecting behaviour -}
-class Subeffect (m :: k -> * -> *) f g where
+class Subeffect (m :: k -> Type -> Type) f g where
     sub :: m f a -> m g a
 

--- a/src/Control/Effect/Cond.hs
+++ b/src/Control/Effect/Cond.hs
@@ -2,12 +2,13 @@
 
 module Control.Effect.Cond where
 
-import GHC.Exts ( Constraint )
+import GHC.Exts (Constraint)
+import Data.Kind (Type)
 
 {-| Provides a conditional using an 'alternation' operation, as opposed to using
    'Subeffect' -}
 
-class Cond (m :: k -> * -> *) where
+class Cond (m :: k -> Type -> Type) where
     type AltInv m (s :: k) (t :: k) :: Constraint
     type AltInv m s t = ()
 

--- a/src/Control/Effect/Counter.hs
+++ b/src/Control/Effect/Counter.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE TypeFamilies, EmptyDataDecls, TypeOperators #-}
 
-module Control.Effect.Counter(Z, S, Counter, tick, (:+)) where
+module Control.Effect.Counter () where
 
-import Control.Effect
+import Control.Effect (Effect(..))
 import Prelude hiding (Monad(..))
+import Data.Kind (Type)
 
 {-| Provides a way to 'count' in the type-level with a monadic interface
     to sum up the individual counts of subcomputations -}
@@ -13,7 +14,7 @@ data Z
 data S n
 
 {-| The counter has no semantic meaning -}
-data Counter n a = Counter { forget :: a }
+data Counter (n :: Type) a = Counter { forget :: a }
 
 {-| Type-level addition -}
 type family n :+ m 
@@ -34,5 +35,3 @@ instance Effect Counter where
 {-| A 'tick' provides a way to increment the counter -}
 tick :: a -> Counter (S Z) a
 tick x = Counter x
-
-    

--- a/src/Control/Effect/CounterNat.hs
+++ b/src/Control/Effect/CounterNat.hs
@@ -1,9 +1,11 @@
-{-# LANGUAGE TypeFamilies, TypeOperators, DataKinds #-}
+{-# LANGUAGE TypeFamilies, 
+             TypeOperators, 
+             DataKinds #-}
 
 module Control.Effect.CounterNat where
 
-import Control.Effect
-import GHC.TypeLits
+import Control.Effect (Effect(Plus, (>>=), return, Inv, Unit))
+import GHC.TypeLits (type (+), Nat)
 import Prelude hiding (Monad(..))
 
 {-| Provides a way to 'count' in the type-level with a monadic interface

--- a/src/Control/Effect/Helpers/List.hs
+++ b/src/Control/Effect/Helpers/List.hs
@@ -4,12 +4,13 @@
 module Control.Effect.Helpers.List where
 
 import Data.Proxy 
+import Data.Kind (Type)
 
-data List (l::[*]) where
+data List (l::[Type]) where
     Nil   :: List '[]
     Cons  :: x -> List xs -> List (x ': xs)
 
-type family (:++) (s :: [*]) (t :: [*]) :: [*] where
+type family (:++) (s :: [Type]) (t :: [Type]) :: [Type] where
     '[] :++ ys       = ys
     (x ': xs) :++ ys = x ': (xs :++ ys)
 
@@ -17,7 +18,7 @@ append :: List s -> List t -> List (s :++ t)
 append Nil xs = xs
 append (Cons x xs) ys = Cons x (append xs ys)
 
-class Split (s :: [*]) (t :: [*]) where
+class Split (s :: [Type]) (t :: [Type]) where
     split :: List (s :++ t) -> (List s, List t)
 
 instance Split '[] xs where

--- a/src/Control/Effect/Parameterised.hs
+++ b/src/Control/Effect/Parameterised.hs
@@ -11,9 +11,10 @@ module Control.Effect.Parameterised ((>>), PMonad(..), fail, ifThenElse) where
 
 -- Bye Monads... as we know them
 import Prelude hiding (fail, Monad(..))
+import Data.Kind (Type)
 
 -- Hello Parameterised Monads
-class PMonad (pm :: k -> k -> * -> *) where
+class PMonad (pm :: k -> k -> Type -> Type) where
   -- Lift pure values into effect-invariant computations
   return :: a -> pm inv inv a
 

--- a/src/Control/Effect/ParameterisedAsGraded.hs
+++ b/src/Control/Effect/ParameterisedAsGraded.hs
@@ -1,20 +1,21 @@
-{-# LANGUAGE KindSignatures, TypeFamilies, ConstraintKinds, PolyKinds, DataKinds #-}
+{-# LANGUAGE KindSignatures, TypeFamilies, ConstraintKinds, PolyKinds, DataKinds, TypeOperators #-}
 
 module Control.Effect.ParameterisedAsGraded where
 
 import Control.Effect
+import Data.Kind (Type)
 
 {-| Implements Bob Atkey's 'parametric monads',
     and also the Control.Monad.Indexed package, by emulating
     indexing by morphisms -}
 
 {-| Data type of morphisms -}
-newtype T (i :: Morph * *) a = T a
+newtype T (i :: Morph Type Type) a = T a
 
 {-| Data type denoting either a morphisms with source and target types, or identity -}
 data Morph a b = M a b | Id
 
-instance Effect (T :: ((Morph * *) -> * -> *)) where
+instance Effect (T :: ((Morph Type Type) -> Type -> Type)) where
     type Unit T = Id
     type Plus T (M a b) (M c d) = M a d
     type Plus T Id (M a b) = M a b

--- a/src/Control/Effect/ReadOnceReader.hs
+++ b/src/Control/Effect/ReadOnceReader.hs
@@ -7,11 +7,12 @@ import Control.Effect
 import Control.Effect.Cond
 import Control.Effect.Helpers.List
 import Prelude    hiding (Monad(..))
+import Data.Kind (Type)
 
 {-| Provides a weak reader monad, which can only read an item once. Provides
    an effect system as a list of the items that have been read -}
 
-data Reader (r :: [*]) a = R { runReader :: (List r -> a) }
+data Reader (r :: [Type]) a = R { runReader :: (List r -> a) }
 
 instance Effect Reader where
     type Inv Reader s t = Split s t

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -1,21 +1,49 @@
-{-# LANGUAGE TypeFamilies, FlexibleInstances, FlexibleContexts,
-             MultiParamTypeClasses, UndecidableInstances, RebindableSyntax,
-             DataKinds, TypeOperators, PolyKinds, ConstraintKinds,
+{-# LANGUAGE TypeFamilies, 
+             FlexibleInstances, 
+             FlexibleContexts,
+             MultiParamTypeClasses, 
+             UndecidableInstances, 
+             RebindableSyntax,
+             DataKinds, 
+             TypeOperators, 
+             PolyKinds, 
+             ConstraintKinds,
              KindSignatures #-}
 
-module Control.Effect.Reader (Reader(..), ask, merge, Mapping(..),
-                              Var(..), Submap, Map(..)) where
+module Control.Effect.Reader 
+    (Reader(..), 
+     ask, 
+     merge, 
+     Mapping(..),
+     Var(..), 
+     Submap, 
+     Map(..)) where
 
 import Control.Effect
+    (Subeffect(..), 
+     Effect(Plus, (>>=), return, Inv, Unit))
+
 import Data.Type.Map
+    (union,
+     Combine,
+     IsMap,
+     Map(..),
+     Mapping(..),
+     Split(..),
+     Submap(..),
+     Union,
+     Unionable,
+     Var(..))
+
 import Prelude hiding (Monad(..))
-import GHC.TypeLits
-import GHC.Exts ( Constraint )
+import GHC.TypeLits (Symbol)
+import GHC.Exts (Constraint)
+import Data.Kind (Type)
 
 {-| Provides a effect-parameterised version of the class reader monad. Effects
    are sets of variable-type pairs, providing an effect system for reader effects. -}
 
-newtype Reader (s :: [Mapping Symbol *]) a = IxR { runReader :: Map s -> a }
+newtype Reader (s :: [Mapping Symbol Type]) a = IxR { runReader :: Map s -> a }
 
 instance Effect Reader where
     type Inv Reader f g = (IsMap f, IsMap g, Split f g (Union f g))

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -1,23 +1,55 @@
-{-# LANGUAGE TypeFamilies, MultiParamTypeClasses, FlexibleInstances,
-             UndecidableInstances, RebindableSyntax,  DataKinds,
-             TypeOperators, PolyKinds, FlexibleContexts, ConstraintKinds,
-             IncoherentInstances, GADTs
+{-# LANGUAGE TypeFamilies, 
+             MultiParamTypeClasses, 
+             FlexibleInstances,
+             UndecidableInstances, 
+             RebindableSyntax,  
+             DataKinds,
+             TypeOperators, 
+             PolyKinds, 
+             FlexibleContexts, 
+             ConstraintKinds,
+             IncoherentInstances, 
+             GADTs, 
+             TypeApplications
              #-}
 
-module Control.Effect.State (Set(..), get, put, State(..), (:->)(..), (:!)(..),
-                                  Eff(..), Action(..), Var(..), union, UnionS,
-                                     Reads(..), Writes(..), Unionable, Sortable, SetLike,
-                                      StateSet,
-                                          --- may not want to export these
-                                          IntersectR, Update, Sort, Split) where
+module Control.Effect.State 
+    (Set(..), 
+     get, 
+     put, 
+     State(..), 
+     (:->)(..), 
+     (:!)(..),
+     Eff(..), 
+     Action(..), 
+     Var(..), 
+     union, 
+     UnionS,
+     Reads(..), 
+     Writes(..), 
+     Unionable, 
+     Sortable, 
+     SetLike,
+     StateSet,
+     --- may not want to export these
+     IntersectR, Update, Sort, Split) where
 
-import Control.Effect
-import Data.Type.Set hiding (Unionable, union, SetLike, Nub, Nubable(..))
+import Control.Effect (Effect(Plus, (>>=), return, Inv, Unit))
+import Data.Type.Set
+    (append,
+     type (:++),
+     Cmp,
+     IsSet,
+     Set(..),
+     Sort,
+     Sortable(..),
+     Split(..),
+     Union)
 import qualified Data.Type.Set as Set
---import Data.Type.Map (Mapping(..), Var(..))
 
 import Prelude hiding (Monad(..),reads)
-import GHC.TypeLits
+import GHC.TypeLits (Symbol, CmpSymbol)
+import Data.Kind (Type)
 
 {-| Provides an effect-parameterised version of the state monad, which gives an
    effect system for stateful computations with annotations that are sets of
@@ -37,7 +69,7 @@ instance Show (Action RW) where
     show _ = "RW"
 
 infixl 2 :->
-data (k :: Symbol) :-> (v :: *) = (Var k) :-> v
+data (k :: Symbol) :-> (v :: Type) = (Var k) :-> v
 
 data Var (k :: Symbol) where Var :: Var k
                              {- Some special defaults for some common names -}
@@ -172,8 +204,8 @@ put _ a = State $ \Empty -> ((), Ext (Var :-> a :! Eff) Empty)
 {-| Captures what it means to be a set of state effects -}
 type StateSet f = (StateSetProperties f, StateSetProperties (Reads f), StateSetProperties (Writes f))
 type StateSetProperties f = (IntersectR f '[], IntersectR '[] f,
-                             UnionS f '[] ~ f, Split f '[] f,
-                             UnionS '[] f ~ f, Split '[] f f,
+                             UnionS f '[] ~ f, Split f ('[] @Type) f,
+                             UnionS '[] f ~ f, Split ('[] @Type) f f,
                              UnionS f f ~ f, Split f f f,
                              Unionable f '[], Unionable '[] f)
 

--- a/src/Control/Effect/Update.hs
+++ b/src/Control/Effect/Update.hs
@@ -5,12 +5,13 @@ module Control.Effect.Update where
 
 import Control.Effect
 import Prelude hiding (Monad(..))
+import Data.Kind (Type)
 
 {-| Parametric effect update monad. A bit like a writer monad specialised to the 'Maybe' monoid, 
    providing a single memory cell that can be updated, but with heterogeneous behaviour. 
    Provides an effect system that explains whether a single memory cell has been updated or not -}
 
-data Eff (w :: Maybe *) where
+data Eff (w :: Maybe Type) where
    Put :: a -> Eff (Just a)
    NoPut :: Eff Nothing
 

--- a/src/Control/Effect/Vector.hs
+++ b/src/Control/Effect/Vector.hs
@@ -25,7 +25,7 @@ append Nil         ys = ys
 append (Cons x xs) ys = Cons x (append xs ys)
 
 instance Effect Vector where
-    -- Effect monoid is (N, *, 1)
+    -- Effect monoid is (N, Type, 1)
     type Inv Vector s t = ()
 
     type Unit Vector = S Z

--- a/src/Control/Effect/WriteOnceWriter.hs
+++ b/src/Control/Effect/WriteOnceWriter.hs
@@ -6,11 +6,12 @@ module Control.Effect.WriteOnceWriter (put, WriteOnce(..)) where
 import Control.Effect
 import Control.Effect.Helpers.List
 import Prelude hiding (Monad(..))
+import Data.Kind (Type)
 
 {-| Provides a kind of writer monad, which can only write an item once 
    (no accumulation), an effect system as a list of the items that have been written -}
 
-data WriteOnce (w :: [*]) a = W { runWriteOnce :: (a, List w) }
+data WriteOnce (w :: [Type]) a = W { runWriteOnce :: (a, List w) }
 
 instance Effect WriteOnce where
     type Inv WriteOnce s t = ()

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -1,21 +1,51 @@
-{-# LANGUAGE GADTs, DataKinds, KindSignatures, TypeOperators, TypeFamilies,
-             MultiParamTypeClasses, FlexibleInstances, UndecidableInstances,
-             ScopedTypeVariables, PolyKinds, FlexibleContexts #-}
+{-# LANGUAGE GADTs, 
+             DataKinds, 
+             KindSignatures, 
+             TypeOperators, 
+             TypeFamilies,
+             MultiParamTypeClasses, 
+             FlexibleInstances, 
+             UndecidableInstances,
+             ScopedTypeVariables, 
+             PolyKinds, 
+             FlexibleContexts #-}
 
-module Control.Effect.Writer(Writer(..), Symbol, put, Mapping(..),
-                             IsMap, Map(..), union, Var(..),
-                             Union, Unionable) where
+module Control.Effect.Writer
+    (Writer(..), 
+     Symbol, 
+     put, 
+     Mapping(..),
+     IsMap, 
+     Map(..), 
+     union, 
+     Var(..),
+     Union, 
+     Unionable) where
 
 import Control.Effect
+    (Subeffect(..), 
+     Effect(Plus, (>>=), return, Inv, Unit)) 
+
 import Data.Type.Map
-import Data.Monoid
-import GHC.TypeLits
+    (union,
+     Combine,
+     IsMap,
+     Map(..),
+     Mapping(..),
+     Nubable(..),
+     Union,
+     Unionable,
+     Var(..))
+     
+import Data.Monoid (Monoid(mempty, mappend))
+import GHC.TypeLits (Symbol )
 import Prelude hiding (Monad(..))
+import Data.Kind (Type)
 
 {-| Provides an effect-parameterised version of the writer monad. Effects
    are maps of variable-type pairs, providing an effect system for writer effects. -}
 
-data Writer (w :: [Mapping Symbol *]) a = Writer { runWriter :: (a, Map w) }
+data Writer (w :: [Mapping Symbol Type]) a = Writer { runWriter :: (a, Map w) }
 
 instance Effect Writer where
     type Inv Writer s t = (IsMap s, IsMap t, Unionable s t)

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,7 +10,7 @@ user-message: ! 'Warning: Specified resolver could not satisfy all dependencies.
 '
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-6.0
+resolver: lts-24.6
 
 # Local packages, usually specified by relative directory name
 packages:
@@ -19,7 +19,6 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-- type-level-sets-0.6.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
1. Switched over from using * to Data.Kind.Type.
2. Cleaned up some formatting.
3. Fixed all warnings.